### PR TITLE
Fix unmount warning in React when unmounting component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,8 +1,120 @@
 {
-    "name": "react-native-svg-animated-linear-gradient",
+    "name": "react-native-content-loader",
     "version": "0.1.4",
     "lockfileVersion": 1,
+    "requires": true,
     "dependencies": {
+        "babel-helper-builder-react-jsx": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-helper-builder-react-jsx/-/babel-helper-builder-react-jsx-6.26.0.tgz",
+            "integrity": "sha1-Of+DE7dci2Xc7/HzHTg+D/KkCKA=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "babel-types": "^6.26.0",
+                "esutils": "^2.0.2"
+            }
+        },
+        "babel-plugin-syntax-flow": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz",
+            "integrity": "sha1-TDqyCiryaqIM0lmVw5jE63AxDI0="
+        },
+        "babel-plugin-syntax-jsx": {
+            "version": "6.18.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
+            "integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+        },
+        "babel-plugin-transform-flow-strip-types": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-flow-strip-types/-/babel-plugin-transform-flow-strip-types-6.22.0.tgz",
+            "integrity": "sha1-hMtnKTXUNxT9wyvOhFaNh0Qc988=",
+            "requires": {
+                "babel-plugin-syntax-flow": "^6.18.0",
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-react-display-name": {
+            "version": "6.25.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-display-name/-/babel-plugin-transform-react-display-name-6.25.0.tgz",
+            "integrity": "sha1-Z+K/Hx6ck6sI25Z5LgU5K/LMKNE=",
+            "requires": {
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-react-jsx": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx/-/babel-plugin-transform-react-jsx-6.24.1.tgz",
+            "integrity": "sha1-hAoCjn30YN/DotKfDA2R9jduZqM=",
+            "requires": {
+                "babel-helper-builder-react-jsx": "^6.24.1",
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-react-jsx-self": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-self/-/babel-plugin-transform-react-jsx-self-6.22.0.tgz",
+            "integrity": "sha1-322AqdomEqEh5t3XVYvL7PBuY24=",
+            "requires": {
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-plugin-transform-react-jsx-source": {
+            "version": "6.22.0",
+            "resolved": "https://registry.npmjs.org/babel-plugin-transform-react-jsx-source/-/babel-plugin-transform-react-jsx-source-6.22.0.tgz",
+            "integrity": "sha1-ZqwSFT9c0tF7PBkmj0vwGX9E7NY=",
+            "requires": {
+                "babel-plugin-syntax-jsx": "^6.8.0",
+                "babel-runtime": "^6.22.0"
+            }
+        },
+        "babel-preset-flow": {
+            "version": "6.23.0",
+            "resolved": "https://registry.npmjs.org/babel-preset-flow/-/babel-preset-flow-6.23.0.tgz",
+            "integrity": "sha1-5xIYiHCFrpoktb5Baa/7WZgWxJ0=",
+            "requires": {
+                "babel-plugin-transform-flow-strip-types": "^6.22.0"
+            }
+        },
+        "babel-preset-react": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/babel-preset-react/-/babel-preset-react-6.24.1.tgz",
+            "integrity": "sha1-umnfrqRfw+xjm2pOzqbhdwLJE4A=",
+            "requires": {
+                "babel-plugin-syntax-jsx": "^6.3.13",
+                "babel-plugin-transform-react-display-name": "^6.23.0",
+                "babel-plugin-transform-react-jsx": "^6.24.1",
+                "babel-plugin-transform-react-jsx-self": "^6.22.0",
+                "babel-plugin-transform-react-jsx-source": "^6.22.0",
+                "babel-preset-flow": "^6.23.0"
+            }
+        },
+        "babel-runtime": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
+            "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+            "requires": {
+                "core-js": "^2.4.0",
+                "regenerator-runtime": "^0.11.0"
+            }
+        },
+        "babel-types": {
+            "version": "6.26.0",
+            "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
+            "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+            "requires": {
+                "babel-runtime": "^6.26.0",
+                "esutils": "^2.0.2",
+                "lodash": "^4.17.4",
+                "to-fast-properties": "^1.0.3"
+            }
+        },
+        "core-js": {
+            "version": "2.5.7",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+            "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw=="
+        },
         "d3-color": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.0.3.tgz",
@@ -11,7 +123,30 @@
         "d3-interpolate": {
             "version": "1.1.5",
             "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.1.5.tgz",
-            "integrity": "sha1-aeCZ/zkhRxblY8muw+qdHqS4p58="
+            "integrity": "sha1-aeCZ/zkhRxblY8muw+qdHqS4p58=",
+            "requires": {
+                "d3-color": "1"
+            }
+        },
+        "esutils": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+            "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+        },
+        "lodash": {
+            "version": "4.17.10",
+            "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+            "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+        },
+        "regenerator-runtime": {
+            "version": "0.11.1",
+            "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+            "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+        },
+        "to-fast-properties": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
+            "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
         }
     }
 }

--- a/package.json
+++ b/package.json
@@ -23,11 +23,12 @@
     ],
     "peerDependencies": {
         "expo": "16.0.0",
+        "prop-types": "^15.5.10",
         "react": "16.0.0-alpha.6",
-        "react-native": "https://github.com/expo/react-native/archive/sdk-16.0.0.tar.gz",
-        "prop-types": "^15.5.10"
+        "react-native": "https://github.com/expo/react-native/archive/sdk-16.0.0.tar.gz"
     },
     "dependencies": {
+        "babel-preset-react": "^6.24.1",
         "d3-interpolate": "^1.1.5"
     }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -82,7 +82,7 @@ export default class ContentLoader extends Component {
         this.currentRequestAnimationFrame = requestAnimationFrame(this._animation);
 
         // Setup loop animation
-        Animated.sequence([
+       this.currentAnimated = Animated.sequence([
             Animated.timing(this._animate, {
                 toValue: 1,
                 duration: this.state.frequence
@@ -91,7 +91,8 @@ export default class ContentLoader extends Component {
                 toValue: 0,
                 duration: this.state.frequence
             })
-        ]).start((event) => {
+        ]);
+        this.currentAnimated.start((event) => {
             if (event.finished) {
                 this.loopAnimation()
             }
@@ -99,7 +100,8 @@ export default class ContentLoader extends Component {
     }
 
     componentWillUnmount() {
-        window.cancelAnimationFrame(this.currentRequestAnimationFrame);
+        cancelAnimationFrame(this.currentRequestAnimationFrame);
+        this.currentAnimated.stop();
     }
 
     render() {

--- a/src/index.js
+++ b/src/index.js
@@ -78,7 +78,8 @@ export default class ContentLoader extends Component {
                 requestAnimationFrame(this._animation);
             }
         }
-        requestAnimationFrame(this._animation);
+
+        this.currentRequestAnimationFrame = requestAnimationFrame(this._animation);
 
         // Setup loop animation
         Animated.sequence([
@@ -96,6 +97,11 @@ export default class ContentLoader extends Component {
             }
         })
     }
+
+    componentWillUnmount() {
+        window.cancelAnimationFrame(this.currentRequestAnimationFrame);
+    }
+
     render() {
         return (
             <View>


### PR DESCRIPTION
**Issues:**
- When developers trying to unmount this component without stopping animation. React throws error:
`Warning: Can't call setState (or forceUpdate) on an unmounted component. This is a no-op, but it indicates a memory leak in your application. To fix, cancel all subscriptions and asynchronous tasks in the componentWillUnmount method.`
**Fixed:**
- Before removing this component. I stopped animation so the component can unmount safely